### PR TITLE
Enable Nullable

### DIFF
--- a/Assets/_Scripts/Assembly.asmdef
+++ b/Assets/_Scripts/Assembly.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Assembly",
+    "rootNamespace": "",
+    "references": [
+        "GUID:33759803a11f4d538227861a78aba30b"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/_Scripts/Assembly.asmdef.meta
+++ b/Assets/_Scripts/Assembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e7430a7fed1932b5c801f9ee3b53f270
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/csc.rsp
+++ b/Assets/_Scripts/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable -nowarn:CS8618

--- a/Assets/_Scripts/csc.rsp.meta
+++ b/Assets/_Scripts/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 669db94b607622c1dbdcdd1e5ee24bd7
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- adds csc.rsp file to set chsarp compiler flags to enable Nullable for Unity
  - adds a -nowarn:CS8618 flag to suppress warning that default Unity analyzers suppress in some cases in IDEs, but Unity Editor for some reason doesn't suppress:
  Non-nullable variable must contain a non-null value when exiting constructor.
- added AssemblyDefinition for main game assembly so the csc.rsp settings only apply to the main game assembly